### PR TITLE
ストリームレスポンスを読む実装

### DIFF
--- a/app/routes/api.chat-messages.tsx
+++ b/app/routes/api.chat-messages.tsx
@@ -1,0 +1,21 @@
+
+export const loader = async (): Promise<any> => {
+  const token = process.env.DIFY_TOKEN
+
+  const response = await fetch('https://api.dify.ai/v1/chat-messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify({
+        "inputs": {},
+        "query": "こんにちは",
+        "response_mode": "streaming",
+        "conversation_id": "",
+        "user": "abc-123",
+        "files": []
+    })
+  });
+  return response
+}

--- a/app/routes/api.chat-messages.tsx
+++ b/app/routes/api.chat-messages.tsx
@@ -1,21 +1,20 @@
-
 export const loader = async (): Promise<any> => {
-  const token = process.env.DIFY_TOKEN
+  const token = process.env.DIFY_TOKEN;
 
-  const response = await fetch('https://api.dify.ai/v1/chat-messages', {
-    method: 'POST',
+  const response = await fetch("https://api.dify.ai/v1/chat-messages", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({
-        "inputs": {},
-        "query": "こんにちは",
-        "response_mode": "streaming",
-        "conversation_id": "",
-        "user": "abc-123",
-        "files": []
-    })
+      inputs: {},
+      query: "200文字くらいのダミーテキストを、改行を使いながら日本語で返して",
+      response_mode: "streaming",
+      conversation_id: "",
+      user: "abc-123",
+      files: [],
+    }),
   });
-  return response
-}
+  return response;
+};

--- a/app/routes/api.chat-messages.tsx
+++ b/app/routes/api.chat-messages.tsx
@@ -1,5 +1,8 @@
-export const loader = async (): Promise<any> => {
+import { ActionFunctionArgs } from "@remix-run/node";
+
+export const action = async ({ request }: ActionFunctionArgs): Promise<any> => {
   const token = process.env.DIFY_TOKEN;
+  const body = (await request.json()) as ChatMessagesRequestBody;
 
   const response = await fetch("https://api.dify.ai/v1/chat-messages", {
     method: "POST",
@@ -9,9 +12,9 @@ export const loader = async (): Promise<any> => {
     },
     body: JSON.stringify({
       inputs: {},
-      query: "200文字くらいのダミーテキストを、改行を使いながら日本語で返して",
+      query: body.query,
       response_mode: "streaming",
-      conversation_id: "",
+      conversation_id: body.conversationId ?? "",
       user: "abc-123",
       files: [],
     }),

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -1,35 +1,36 @@
 import { useState } from "react";
+import { parseChunkText } from "~/streamParser";
+import { ChunkChatCompletionResponse } from "~/types/chatMessagesResponse";
 
-export default function Chat() { 
-  const [text, setText] = useState<string>('')
+export default function Chat() {
+  const [text, setText] = useState<string>("");
 
   const sendMessage = async (): Promise<void> => {
-    const response = await fetch('/api/chat-messages')
+    const response = await fetch("/api/chat-messages");
 
-    const reader = response.body?.pipeThrough(new TextDecoderStream()).getReader()
-    while (true) {
-      const {value, done } = await reader?.read()
+    const reader = response.body
+      ?.pipeThrough(new TextDecoderStream())
+      .getReader();
+    for (;;) {
+      const { value, done } = await reader?.read();
       if (done) break;
-      console.log('Received', value)
-      const raws = value.toString().split('\n').filter(line => line.trim() !== '')
-      for (const raw of raws) {
-        const message = raw.replace(/^data: /, '')
-        const parsedData = JSON.parse(message)
-        console.log({parsedData})
-        if (parsedData.answer) {
-          setText((prevText) => prevText + parsedData.answer)
+      const parsedChunkList =
+        parseChunkText<ChunkChatCompletionResponse>(value);
+      parsedChunkList.forEach((chunk) => {
+        if (chunk.event === "message" && chunk.answer) {
+          setText((prevText) => prevText + chunk.answer);
         }
-      }
+      });
     }
-    reader?.releaseLock()
-  }
+    reader?.releaseLock();
+  };
 
   return (
     <div>
       <h1>Chat page</h1>
       <hr />
       <button onClick={sendMessage}>Send Message</button>
-      <p>{ text }</p>
+      <p>{text}</p>
     </div>
-  )
+  );
 }

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -1,0 +1,9 @@
+
+export default function Chat() { 
+
+  return (
+    <div>
+      <h1>Chat page</h1>
+    </div>
+  )
+}

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -6,7 +6,17 @@ export default function Chat() {
   const [text, setText] = useState<string>("");
 
   const sendMessage = async (): Promise<void> => {
-    const response = await fetch("/api/chat-messages");
+    const messageBody: ChatMessagesRequestBody = {
+      query: "200文字程度のダミーテキストを日本語で返してください",
+    };
+    console.log(crypto.randomUUID());
+    const response = await fetch("/api/chat-messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ ...messageBody }),
+    });
 
     const reader = response.body
       ?.pipeThrough(new TextDecoderStream())

--- a/app/routes/chat.tsx
+++ b/app/routes/chat.tsx
@@ -1,9 +1,35 @@
+import { useState } from "react";
 
 export default function Chat() { 
+  const [text, setText] = useState<string>('')
+
+  const sendMessage = async (): Promise<void> => {
+    const response = await fetch('/api/chat-messages')
+
+    const reader = response.body?.pipeThrough(new TextDecoderStream()).getReader()
+    while (true) {
+      const {value, done } = await reader?.read()
+      if (done) break;
+      console.log('Received', value)
+      const raws = value.toString().split('\n').filter(line => line.trim() !== '')
+      for (const raw of raws) {
+        const message = raw.replace(/^data: /, '')
+        const parsedData = JSON.parse(message)
+        console.log({parsedData})
+        if (parsedData.answer) {
+          setText((prevText) => prevText + parsedData.answer)
+        }
+      }
+    }
+    reader?.releaseLock()
+  }
 
   return (
     <div>
       <h1>Chat page</h1>
+      <hr />
+      <button onClick={sendMessage}>Send Message</button>
+      <p>{ text }</p>
     </div>
   )
 }

--- a/app/streamParser.ts
+++ b/app/streamParser.ts
@@ -1,0 +1,19 @@
+/**
+ * ストリームレスポンスを任意のオブジェクトにパースする
+ * @param chunkText ストリームレスポンスのテキスト
+ * @returns パースした結果のストリームレスポンス
+ */
+const parseChunkText = <T>(chunkText: string): T[] => {
+  console.log({ chunkText });
+  const raws = chunkText.split("\n").filter((line) => line.trim() !== "");
+  return raws.map((raw) => {
+    const response = raw.replace(/^data: /, "");
+    try {
+      return JSON.parse(response);
+    } catch (error) {
+      console.log(error, response);
+    }
+  });
+};
+
+export { parseChunkText };

--- a/app/types/chatMessagesRequest.d.ts
+++ b/app/types/chatMessagesRequest.d.ts
@@ -1,0 +1,13 @@
+/**
+ * ユーザーが送信する会話内容
+ */
+interface ChatMessagesRequestBody {
+  /**
+   * ユーザー入力、質問内容
+   */
+  query: string;
+  /**
+   * 会話ID
+   */
+  conversationId?: string;
+}

--- a/app/types/chatMessagesResponse.d.ts
+++ b/app/types/chatMessagesResponse.d.ts
@@ -1,0 +1,115 @@
+// Difyアプリケーションのレスポンスデータ
+
+// Common interface properties
+interface BaseStreamResponse {
+  task_id: string;
+  message_id: string;
+  conversation_id: string;
+  created_at: number;
+}
+
+// Message event response
+interface MessageStreamResponse extends BaseStreamResponse {
+  event: "message";
+  answer: string;
+}
+
+// Agent message event response
+interface AgentMessageStreamResponse extends BaseStreamResponse {
+  event: "agent_message";
+  answer: string;
+}
+
+// TTS message event response
+interface TTSMessageStreamResponse extends BaseStreamResponse {
+  event: "tts_message";
+  audio: string;
+}
+
+// TTS message end event response
+interface TTSMessageEndStreamResponse extends BaseStreamResponse {
+  event: "tts_message_end";
+  audio: string;
+}
+
+// File information
+interface MessageFile {
+  file_id: string;
+}
+
+// Agent thought event response
+interface AgentThoughtStreamResponse extends BaseStreamResponse {
+  event: "agent_thought";
+  id: string;
+  position: number;
+  thought: string;
+  observation: string;
+  tool: string;
+  tool_input: string;
+  message_files: MessageFile[];
+}
+
+// Message file event response
+interface MessageFileStreamResponse {
+  event: "message_file";
+  id: string;
+  type: "image";
+  belongs_to: "assistant";
+  url: string;
+  conversation_id: string;
+}
+
+// Usage information
+interface Usage {
+  [key: string]: any;
+}
+
+// Retriever resource information
+interface RetrieverResource {
+  [key: string]: any;
+}
+
+// Message end event response
+interface MessageEndStreamResponse extends BaseStreamResponse {
+  event: "message_end";
+  metadata: {
+    usage: Usage;
+    retriever_resources: RetrieverResource[];
+  };
+}
+
+// Message replace event response
+interface MessageReplaceStreamResponse extends BaseStreamResponse {
+  event: "message_replace";
+  answer: string;
+}
+
+// Error event response
+interface ErrorStreamResponse {
+  event: "error";
+  task_id: string;
+  message_id: string;
+  status: number;
+  code: string;
+  message: string;
+}
+
+// Ping event response
+interface PingStreamResponse {
+  event: "ping";
+}
+
+// Union type of all possible stream responses
+type ChunkChatCompletionResponse =
+  | MessageStreamResponse
+  | AgentMessageStreamResponse
+  | TTSMessageStreamResponse
+  | TTSMessageEndStreamResponse
+  | AgentThoughtStreamResponse
+  | MessageFileStreamResponse
+  | MessageEndStreamResponse
+  | MessageReplaceStreamResponse
+  | ErrorStreamResponse
+  | PingStreamResponse;
+
+export { ChunkChatCompletionResponse };


### PR DESCRIPTION
## 概要
DifyのAPIに繋いで、ストリームレスポンスを画面に出力する

## 修正内容
- プロキシのPOSTエンドポイントを作成
- ボタンを押したらリクエストが送信されるように実装

## 備考
